### PR TITLE
Intermediate single-threaded version

### DIFF
--- a/src/aleo.rs
+++ b/src/aleo.rs
@@ -1,0 +1,14 @@
+use {crate::eclipse, std::result::Result};
+
+pub struct DummyProofGenerator {}
+
+impl eclipse::ProofGenerator for DummyProofGenerator {
+    fn generate_proof(&self, slot: u64, votes: Vec<eclipse::Vote>) -> Result<(), String> {
+        println!(
+            "proof generated for slot {} with {} votes",
+            slot,
+            votes.len()
+        );
+        Ok(())
+    }
+}

--- a/src/eclipse.rs
+++ b/src/eclipse.rs
@@ -1,0 +1,22 @@
+use std::result::Result;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Vote {
+    signature: Vec<u8>,
+    public_key: Vec<u8>,
+    message: Vec<u8>,
+}
+
+impl Vote {
+    pub fn new(signature: Vec<u8>, public_key: Vec<u8>, message: Vec<u8>) -> Self {
+        Vote {
+            signature,
+            public_key,
+            message,
+        }
+    }
+}
+
+pub trait ProofGenerator {
+    fn generate_proof(&self, slot: u64, votes: Vec<Vote>) -> Result<(), String>;
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,16 +3,12 @@
 use {
     clap::{crate_description, crate_name, crate_version, App, Arg},
     solana_client::rpc_client::RpcClient,
-    solana_sdk::clock::Slot,
-    std::{
-        str::FromStr,
-        sync::mpsc::{channel, Receiver, Sender},
-        thread,
-        time::Duration,
-    },
+    std::{str::FromStr, time::Duration},
     url::Url,
 };
 
+mod aleo;
+mod eclipse;
 mod solana;
 
 fn main() {
@@ -66,19 +62,7 @@ fn main() {
         None => 0,
     };
 
-    let (proof_generator, vote_collections): (Sender<(Slot, Vec<solana::Vote>)>, Receiver<(_, _)>) =
-        channel();
-
-    thread::spawn(move || {
-        while let Ok((slot, slot_votes)) = vote_collections.recv() {
-            println!(
-                "slot {} ready for proof generation. {} votes collected.",
-                slot,
-                slot_votes.len()
-            );
-        }
-    });
-
+    let proof_generator = aleo::DummyProofGenerator {};
     let vote_collector = solana::VoteCollector::new(confirmation_threshold, proof_generator);
     let mut block_processor = solana::BlockProcessor::new(client, vote_collector);
 


### PR DESCRIPTION
This change makes proof generation a blocking operation and drops the
use of separate proof generation thread.

The interface for proof generator is currently abstracted via trait that
is used in solana client logic via generics, but this is ought to change
next due to unnecessary boilerplate needed for such construct.

Ping @whalelephant