### PR TITLE
Slot and Block naming & clippy

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,12 +16,12 @@ fn main() {
         .about(crate_description!())
         .version(crate_version!())
         .arg(
-            Arg::with_name("block_height")
-                .long("block_height")
-                .value_name("BLOCK HEIGHT")
+            Arg::with_name("slot")
+                .long("slot_number")
+                .value_name("SLOT")
                 .takes_value(true)
                 .validator(is_u64)
-                .help("Initial block height to process from"),
+                .help("Initial slot to process from; skipped if slot does not have a block"),
         )
         .arg(
             Arg::with_name("json_rpc_url")
@@ -57,7 +57,7 @@ fn main() {
     let confirmation_threshold = usize::from_str(matches.value_of("threshold").unwrap()).unwrap();
     let client = RpcClient::new(url.to_string());
 
-    let start_slot = match matches.value_of("block_height") {
+    let start_slot = match matches.value_of("slot") {
         Some(bh) => u64::from_str(bh).unwrap(),
         None => 0,
     };


### PR DESCRIPTION

This PR 
- makes sure that we are getting the right block from user input (Slot). 
- clippy fixes

---
In the case  that the slot does not have transactions, we move onto the next slot and therefore the next block.
In the case, the log prints the following: 

```
found block 97587587 from parent slot 100861710 with 150 transactions
150 transactions decoded
successfully verified signature; adding to slot signatures
successfully verified signature; adding to slot signatures
current network slot: 100862872, processing slot 100861712
current network slot: 100862898, processing slot 100861713
current network slot: 100862924, processing slot 100861714
current network slot: 100862949, processing slot 100861715
current network slot: 100862970, processing slot 100861716
current network slot: 100862984, processing slot 100861717
current network slot: 100863008, processing slot 100861718
current network slot: 100863053, processing slot 100861719
current network slot: 100863078, processing slot 100861720
found block 97587588 from parent slot 100861711 with 325 transactions
```

Here we can see that the consecutive blocks `97587587` and `97587588` had couple of slots in between. 

