### PR TITLE
Process Aleo transactions in a loop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,22 @@ path = "src/aleo-to-solana/main.rs"
 [dependencies]
 bs58 = "0.4.0"
 clap = "2.33.1"
+derivative = "2"
 ed25519-dalek = "=1.0.1"
+serde = "1.0.131"
 serde_json = "1.0.56"
+snarkos-storage = { git = "https://github.com/AleoHQ/snarkOS.git", branch = "testnet2" }
+snarkvm-algorithms = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "ff10c20" }
+snarkvm-curves = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "ff10c20" }
+snarkvm-fields = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "ff10c20" }
+snarkvm = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "ff10c20" }
 solana-client = "1.8.3"
 solana-vote-program = "1.8.3"
 solana-sdk = "1.8.3"
 solana-transaction-status = "1.8.3"
 ticker = "0.1.1"
 url = "2.2.2"
-anyhow = "1"
+anyhow = "1.0.52"
 tokio = { version = "1.8", features = ["full"] }
 tracing = "0.1"
 jsonrpsee = { version = "0.6.0", features = ["macros", "http-client"], git = "https://github.com/whalelephant/jsonrpsee", branch = "string-id-request"}
@@ -31,8 +38,5 @@ beef = { version = "0.5.1", features = ["impl_serde"] }
 
 [dev-dependencies]
 jsonrpsee-types = "0.6.1"
-serde = "1.0.131"
 json-rpc-types= "1.0"
 jsonrpc-core = "18"
-
-

--- a/src/aleo-to-solana/main.rs
+++ b/src/aleo-to-solana/main.rs
@@ -1,12 +1,156 @@
-use jsonrpsee::{http_client::HttpClientBuilder, types::traits::Client};
+use {
+    anyhow::Result,
+    core::arch::x86_64::_rdtsc,
+    derivative::Derivative,
+    jsonrpsee::{
+        http_client::{HttpClient, HttpClientBuilder},
+        rpc_params,
+        types::traits::Client,
+    },
+    serde::{Deserialize, Serialize},
+    snarkvm::{
+        dpc::testnet2::Testnet2,
+        dpc::traits::Network,
+        prelude::{Block, Transaction},
+    },
+    snarkvm_algorithms::merkle_tree::*,
+    std::{sync::Arc, thread::sleep, time::Duration},
+};
+
+#[derive(Derivative)]
+#[derivative(Clone(bound = "N: Network"), Debug(bound = "N: Network"))]
+pub struct PhantomTree<N: Network> {
+    #[derivative(Debug = "ignore")]
+    tree: Arc<MerkleTree<N::TransactionIDParameters>>,
+}
+
+impl<N: Network> PhantomTree<N> {
+    /// Initializes an empty local transitions tree.
+    pub fn new() -> Result<Self> {
+        Ok(Self {
+            tree: Arc::new(MerkleTree::<N::TransactionIDParameters>::new::<
+                N::TransitionID,
+            >(
+                Arc::new(N::transaction_id_parameters().clone()), &vec![]
+            )?),
+        })
+    }
+
+    /// Returns the local transitions root.
+    pub fn root(&self) -> N::TransactionID {
+        (*self.tree.root()).into()
+    }
+}
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     // Assuming that the snarkOS is running locally, by default 3032 is the rpc server port
     let url = format!("http://{}", "127.0.0.1:3032");
     let client = HttpClientBuilder::default().build(url)?;
-    let response: Result<serde_json::Value, _> = client.request("latestblock", None).await;
-    println!("response: {:?}", response);
+    let mut cur_block: Block<Testnet2>;
+    let mut prev_block: Option<Block<Testnet2>> = None;
+
+    loop {
+        println!("fetching latestblock");
+        let response: serde_json::Value = client.request("latestblock", None).await?;
+
+        println!("parsing block");
+        cur_block = serde_json::from_value(response)?;
+
+        println!("checking if it's new");
+        if let Some(ref pb) = prev_block {
+            if pb.hash() == cur_block.hash() {
+                println!(
+                    "sleeping: prev_block == cur_block ({} == {})",
+                    pb.hash(),
+                    cur_block.hash()
+                );
+                // Sleep
+                sleep(Duration::from_millis(5000));
+                continue;
+            }
+        }
+
+        println!("processing block");
+        process_block(&cur_block, &client).await?;
+
+        prev_block = Some(cur_block);
+    }
+}
+
+async fn process_block(block: &Block<Testnet2>, client: &HttpClient) -> anyhow::Result<()> {
+    for tx_id in block.transactions().transaction_ids() {
+        let response: Result<serde_json::Value, _> = client
+            .request("gettransaction", rpc_params!(tx_id.to_string()))
+            .await;
+
+        /// Additional metadata included with a transaction response
+        #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+        pub struct GetTransactionResponse {
+            pub transaction: Transaction<Testnet2>,
+            #[serde(skip)]
+            pub metadata: String,
+        }
+
+        match response {
+            Ok(response) => {
+                let response: Result<GetTransactionResponse, _> = serde_json::from_value(response);
+
+                match response {
+                    Ok(tx) => {
+                        let mut start: u64;
+                        unsafe {
+                            start = _rdtsc();
+                        };
+
+                        let mut is_valid = tx.transaction.is_valid();
+
+                        let mut end: u64;
+                        unsafe {
+                            end = _rdtsc();
+                        };
+
+                        let mut instructions = end - start;
+
+                        println!(
+                            "Transaction validation - TSC: {}, is_valid: {}",
+                            instructions, is_valid
+                        );
+
+                        for t in tx.transaction.transitions() {
+                            // Initialize a local transitions tree.
+                            let tree = PhantomTree::<Testnet2>::new()
+                                .expect("simple constructor must always succeed");
+
+                            unsafe {
+                                start = _rdtsc();
+                            };
+                            is_valid = t.verify(
+                                tx.transaction.inner_circuit_id(),
+                                tx.transaction.ledger_root(),
+                                tree.root(),
+                            );
+                            unsafe {
+                                end = _rdtsc();
+                            };
+                            instructions = end - start;
+                            println!(
+                                "transition validation - TSC: {}, is_valid: {}",
+                                instructions, is_valid
+                            );
+                        }
+                    }
+                    Err(err) => {
+                        println!("error: failed to deserialize transaction: {}", err);
+                    }
+                }
+            }
+            Err(err) => {
+                println!("failed to get transaction: {}", err);
+            }
+        }
+    }
+
     Ok(())
 }
 
@@ -21,15 +165,17 @@ mod tests {
     fn it_serde() {
         let id = Id::Number(0);
         let from_eclipse = RequestSer::new(id, "latestblock", None);
-        let from_eclipse_str = serde_json::to_string(&from_eclipse).unwrap();
+        let from_eclipse_str =
+            serde_json::to_string(&from_eclipse).expect("value constructed above can't fail");
 
         // Print out from the Aleo node receiving the request before parsing
         // b"{\"jsonrpc\":\"2.0\",\"id\":0,\"method\":\"getblock\"}";
-        let aleo_req: Request<Params> =
-            serde_json::from_slice(from_eclipse_str.as_bytes()).unwrap();
+        let aleo_req: Request<Params> = serde_json::from_slice(from_eclipse_str.as_bytes())
+            .expect("from_eclipse_str constructed above");
 
-        let aleo_req_str = serde_json::to_string(&aleo_req).unwrap();
-        let parsed_aleo_req: SeeRequest = serde_json::from_slice(aleo_req_str.as_bytes()).unwrap();
+        let aleo_req_str = serde_json::to_string(&aleo_req).expect("request constructed above");
+        let parsed_aleo_req: SeeRequest = serde_json::from_slice(aleo_req_str.as_bytes())
+            .expect("aleo_req_str constructed above");
 
         assert_eq!(parsed_aleo_req.method, from_eclipse.method);
         assert_eq!(parsed_aleo_req.id, from_eclipse.id);
@@ -37,6 +183,9 @@ mod tests {
             parsed_aleo_req.params.is_none(),
             from_eclipse.params.is_none()
         );
-        assert_eq!(serde_json::to_string(&aleo_req).unwrap(), from_eclipse_str);
+        assert_eq!(
+            serde_json::to_string(&aleo_req).expect("aleo_req constructed above"),
+            from_eclipse_str
+        );
     }
 }


### PR DESCRIPTION
This change will add support for continuous polling of latest block and
in occurrance of a new block, it will validate its transactions and
verify the transition's proof inside each transaction.

There's also rough timing of validation and proof verification via use
of RDTSC, but this must be treated with a grain of salt. It's mostly a
rough estimation of instructions that take place during the operation,
but due to way how multi-core processors work, it's not fully reliable
in all cases.